### PR TITLE
Add color legend to Canvas heatmap (Fixes #46)

### DIFF
--- a/client/components/CanvasInteractiveMap.tsx
+++ b/client/components/CanvasInteractiveMap.tsx
@@ -801,6 +801,63 @@ export function CanvasInteractiveMap({
         </Badge>
       </div>
 
+      {/* Color Legend - Enhanced Premium Style */}
+      {ncData && (
+        <div className="absolute bottom-4 right-4 z-[1000] bg-transparent p-4">
+          <div className="flex items-center gap-4">
+            {/* Color bar */}
+            <div className="relative">
+              <div 
+                className="w-4 h-36 rounded-sm border-2 border-gray-800"
+                style={{
+                  background: `linear-gradient(to bottom, 
+                    #8b0000 0%,     /* Dark reddish-brown (298) */
+                    #ff8c00 25%,    /* Orange (297) */
+                    #ffff00 50%,    /* Yellowish-green (296) */
+                    #00bfff 75%,    /* Light blue/cyan (295) */
+                    #191970 100%)`  /* Very dark purplish-blue (294) */
+                }}
+              />
+            </div>
+            
+            {/* Values */}
+            <div className="flex flex-col justify-between h-36">
+              <div className="flex items-center">
+                <div className="w-3 h-0.5 bg-gray-800 mr-3"></div>
+                <span className="text-sm font-semibold text-gray-800">298</span>
+              </div>
+              <div className="flex items-center">
+                <div className="w-3 h-0.5 bg-gray-800 mr-3"></div>
+                <span className="text-sm font-semibold text-gray-800">297</span>
+              </div>
+              <div className="flex items-center">
+                <div className="w-3 h-0.5 bg-gray-800 mr-3"></div>
+                <span className="text-sm font-semibold text-gray-800">296</span>
+              </div>
+              <div className="flex items-center">
+                <div className="w-3 h-0.5 bg-gray-800 mr-3"></div>
+                <span className="text-sm font-semibold text-gray-800">295</span>
+              </div>
+              <div className="flex items-center">
+                <div className="w-3 h-0.5 bg-gray-800 mr-3"></div>
+                <span className="text-sm font-semibold text-gray-800">294</span>
+              </div>
+            </div>
+            
+            {/* Parameter name */}
+            <div 
+              className="text-sm font-medium text-gray-800"
+              style={{
+                writingMode: 'vertical-rl',
+                textOrientation: 'mixed'
+              }}
+            >
+              Sea Surface Temperature (K)
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Tooltip */}
       {hoveredPoint && (
         <div


### PR DESCRIPTION
I added a color legend to the Canvas heatmap so users can actually understand what the colors mean.

The legend shows a vertical gradient bar (294K → 298K).

Added numeric ticks on the side (294, 295, 296, 297, 298).

Label included: Sea Surface Temperature (K).

Colors go from dark blue (low) → dark red (high).

Only renders when there’s data, so it doesn’t clutter the UI.

This makes it clear what each color stands for instead of just guessing.
Tested locally and it looks clean and responsive.

Part of Issue #46.