### PR TITLE
Fix timeline display 

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -30,9 +30,9 @@ export default function NingalooResearchApp() {
   ]);
 
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>({
-    start: new Date("2025-09-12T00:00:00Z"),
-    end: new Date("2025-09-12T12:00:00Z"), // 设置为12小时后，避免水合错误
-    granularity: "hours",
+    start: new Date(Date.now() - 24 * 60 * 60 * 1000), // 24 hours ago
+    end: new Date(), // now
+    granularity: "day",
   });
 
   const [expandedParams, setExpandedParams] = useState(false);
@@ -88,7 +88,7 @@ export default function NingalooResearchApp() {
         setSelectedTimeRange({
           start: new Date("2025-09-12T00:00:00Z"),
           end: new Date(),
-          granularity: "hours",
+          granularity: "day",
         });
       }
     } else {
@@ -96,7 +96,7 @@ export default function NingalooResearchApp() {
       setSelectedTimeRange({
         start: new Date("2025-09-12T00:00:00Z"),
         end: new Date(),
-        granularity: "hours",
+        granularity: "day",
       });
     }
   }, []);

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -84,7 +84,7 @@ export default function NingalooResearchApp() {
         });
       } catch (error) {
         console.error("Failed to parse stored time range:", error);
-        // 如果解析失败，设置默认时间范围
+        // If parsing fails, set default time range
         setSelectedTimeRange({
           start: new Date("2025-09-12T00:00:00Z"),
           end: new Date(),
@@ -92,7 +92,7 @@ export default function NingalooResearchApp() {
         });
       }
     } else {
-      // 如果没有存储的时间范围，设置默认时间范围
+      // If no stored time range, set default time range
       setSelectedTimeRange({
         start: new Date("2025-09-12T00:00:00Z"),
         end: new Date(),

--- a/client/components/CanvasInteractiveMap.tsx
+++ b/client/components/CanvasInteractiveMap.tsx
@@ -357,7 +357,7 @@ function CanvasHeatmapOverlay({
     const cols = data[0].length;
 
     // Adjust canvas size based on data density
-    const density = Math.max(1, Math.min(4, Math.sqrt(rows * cols / 50000))); // 自动调整密度
+    const density = Math.max(1, Math.min(4, Math.sqrt(rows * cols / 50000))); // Auto-adjust density
     canvas.width = cols * density;
     canvas.height = rows * density;
 
@@ -395,7 +395,7 @@ function CanvasHeatmapOverlay({
         // Draw pixel block - note: Canvas y-axis is top-to-bottom, so we need to flip
         // For pcolormesh: data[i][j] corresponds to lat[i], lon[j]
         const x = j * density;
-        const y = (rows - 1 - i) * density; // 翻转Y轴以匹配地理坐标
+        const y = (rows - 1 - i) * density; // Flip Y-axis to match geographic coordinates
         ctx.fillRect(x, y, density, density);
       }
     }
@@ -536,7 +536,7 @@ export function CanvasInteractiveMap({
   const currentParam = availableParameters.find((p) => p.id === parameter);
   const satelliteMapping = SATELLITE_MAPPING[parameter as keyof typeof SATELLITE_MAPPING];
 
-  // 获取当前时间戳和文件名 (与之前相同的逻辑)
+  // Get current timestamp and filename (same logic as before)
   const currentTimestamp = useMemo(() => {
     if (!satelliteMapping) return null;
 
@@ -567,7 +567,7 @@ export function CanvasInteractiveMap({
       if (parameter === "ssth") {
         return `${currentTimestamp}.nc`;
       } else if (parameter === "ssha-swot") {
-        // SWOT: 获取可用的NC文件
+        // SWOT: get available NC files
         const ncFiles = await getParameterFiles(parameter, "nc");
         if (ncFiles && ncFiles.length > 0) {
           return ncFiles[0].filename;
@@ -595,15 +595,15 @@ export function CanvasInteractiveMap({
     }
   }, [parameter, satelliteMapping, getParameterFiles, currentTimestamp]);
 
-  // 获取实际数据的时间戳（用于显示）
+  // Get actual data timestamp (for display)
   const actualDataTimestamp = useMemo(() => {
     if (!ncData?.filename) return null;
     
-    // 从文件名中提取时间戳
+    // Extract timestamp from filename
     const filename = ncData.filename;
     
     if (parameter === "ssth") {
-      // Himawari格式: YYYYMMDDHHMMSS.nc -> 显示为可读格式
+      // Himawari format: YYYYMMDDHHMMSS.nc -> display as readable format
       const timestamp = filename.replace('.nc', '');
       const year = timestamp.substring(0, 4);
       const month = timestamp.substring(4, 6);
@@ -613,8 +613,8 @@ export function CanvasInteractiveMap({
       const second = timestamp.substring(12, 14);
       return `${day}/${month}/${year}, ${hour}:${minute}:${second}`;
     } else if (parameter === "ssha-swot") {
-      // SWOT格式: subset_SWOT_L3_LR_SSH_Expert_029_062_20250226T145417_20250226T154543_v2.0.1.nc
-      // 提取 20250226T145417 部分
+      // SWOT format: subset_SWOT_L3_LR_SSH_Expert_029_062_20250226T145417_20250226T154543_v2.0.1.nc
+      // Extract 20250226T145417 part
       const match = filename.match(/(\d{8})T(\d{6})/);
       if (match) {
         const datePart = match[1]; // 20250226
@@ -629,7 +629,7 @@ export function CanvasInteractiveMap({
       }
       return null;
     } else {
-      // Sentinel-3格式: YYYYMMDD_HHMMSS.nc -> 显示为可读格式
+      // Sentinel-3 format: YYYYMMDD_HHMMSS.nc -> display as readable format
       const timestamp = filename.replace('.nc', '');
       const [datePart, timePart] = timestamp.split('_');
       const year = datePart.substring(0, 4);
@@ -642,7 +642,7 @@ export function CanvasInteractiveMap({
     }
   }, [ncData?.filename, parameter]);
 
-  // 加载地图数据 (与之前相同的逻辑)
+  // Load map data (same logic as before)
   const loadMapData = useCallback(async () => {
     if (!satelliteMapping) {
       setError("Unsupported parameter for interactive map");
@@ -684,7 +684,7 @@ export function CanvasInteractiveMap({
     loadMapData();
   }, [loadMapData]);
 
-  // 计算地图中心和边界
+  // Calculate map center and bounds
   const mapCenter = useMemo(() => {
     if (!ncData) return [-22.0, 114.0];
     

--- a/client/components/CanvasInteractiveMap.tsx
+++ b/client/components/CanvasInteractiveMap.tsx
@@ -595,6 +595,53 @@ export function CanvasInteractiveMap({
     }
   }, [parameter, satelliteMapping, getParameterFiles, currentTimestamp]);
 
+  // 获取实际数据的时间戳（用于显示）
+  const actualDataTimestamp = useMemo(() => {
+    if (!ncData?.filename) return null;
+    
+    // 从文件名中提取时间戳
+    const filename = ncData.filename;
+    
+    if (parameter === "ssth") {
+      // Himawari格式: YYYYMMDDHHMMSS.nc -> 显示为可读格式
+      const timestamp = filename.replace('.nc', '');
+      const year = timestamp.substring(0, 4);
+      const month = timestamp.substring(4, 6);
+      const day = timestamp.substring(6, 8);
+      const hour = timestamp.substring(8, 10);
+      const minute = timestamp.substring(10, 12);
+      const second = timestamp.substring(12, 14);
+      return `${day}/${month}/${year}, ${hour}:${minute}:${second}`;
+    } else if (parameter === "ssha-swot") {
+      // SWOT格式: subset_SWOT_L3_LR_SSH_Expert_029_062_20250226T145417_20250226T154543_v2.0.1.nc
+      // 提取 20250226T145417 部分
+      const match = filename.match(/(\d{8})T(\d{6})/);
+      if (match) {
+        const datePart = match[1]; // 20250226
+        const timePart = match[2]; // 145417
+        const year = datePart.substring(0, 4);
+        const month = datePart.substring(4, 6);
+        const day = datePart.substring(6, 8);
+        const hour = timePart.substring(0, 2);
+        const minute = timePart.substring(2, 4);
+        const second = timePart.substring(4, 6);
+        return `${day}/${month}/${year}, ${hour}:${minute}:${second}`;
+      }
+      return null;
+    } else {
+      // Sentinel-3格式: YYYYMMDD_HHMMSS.nc -> 显示为可读格式
+      const timestamp = filename.replace('.nc', '');
+      const [datePart, timePart] = timestamp.split('_');
+      const year = datePart.substring(0, 4);
+      const month = datePart.substring(4, 6);
+      const day = datePart.substring(6, 8);
+      const hour = timePart.substring(0, 2);
+      const minute = timePart.substring(2, 4);
+      const second = timePart.substring(4, 6);
+      return `${day}/${month}/${year}, ${hour}:${minute}:${second}`;
+    }
+  }, [ncData?.filename, parameter]);
+
   // 加载地图数据 (与之前相同的逻辑)
   const loadMapData = useCallback(async () => {
     if (!satelliteMapping) {
@@ -785,7 +832,7 @@ export function CanvasInteractiveMap({
         </Badge>
         <Badge className="bg-white/20 backdrop-blur text-white border-white/30 whitespace-nowrap">
           <div className="text-xs truncate">
-            {timeRange.start.toLocaleString()}
+            {actualDataTimestamp || timeRange.start.toLocaleString()}
           </div>
         </Badge>
 

--- a/client/components/TimelineSlider.tsx
+++ b/client/components/TimelineSlider.tsx
@@ -265,16 +265,34 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
 
           {/* Timeline markers */}
           <div className="absolute -bottom-6 left-0 right-0 flex justify-between text-xs text-cyan-200">
-            {Array.from({ length: 7 }, (_, i) => {
-              const markerTime = new Date(fixedStartDate.getTime() + (totalDuration * i) / 6);
-              const localTime = markerTime.toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-              });
-              return <span key={i}>{localTime}</span>;
-            })}
+            {timeRange.granularity === "day" ? (
+              // Day mode: display 24 hourly markers, time only
+              Array.from({ length: 25 }, (_, i) => {
+                const markerTime = new Date(fixedStartDate.getTime() + (totalDuration * i) / 24);
+                const localTime = markerTime.toLocaleTimeString("en-US", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  hour12: false, // 24-hour format
+                });
+                return (
+                  <span key={i} className="text-xs">
+                    {localTime}
+                  </span>
+                );
+              })
+            ) : (
+              // Week and All modes: display 7 marker points
+              Array.from({ length: 7 }, (_, i) => {
+                const markerTime = new Date(fixedStartDate.getTime() + (totalDuration * i) / 6);
+                const localTime = markerTime.toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                });
+                return <span key={i}>{localTime}</span>;
+              })
+            )}
           </div>
           
           {/* Current Selection Indicator */}

--- a/client/components/TimelineSlider.tsx
+++ b/client/components/TimelineSlider.tsx
@@ -27,18 +27,36 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
   const lastTimeRef = useRef<number>(0);
 
   const granularityOptions = [
-    { id: "months", label: "Months", duration: 30 * 24 * 60 * 60 * 1000 },
-    { id: "weeks", label: "Weeks", duration: 7 * 24 * 60 * 60 * 1000 },
-    { id: "days", label: "Days", duration: 24 * 60 * 60 * 1000 },
-    { id: "hours", label: "Hours", duration: 60 * 60 * 1000 },
+    { id: "day", label: "Day (24h)", duration: 24 * 60 * 60 * 1000 },
+    { id: "week", label: "Week (7 days)", duration: 7 * 24 * 60 * 60 * 1000 },
+    { id: "all", label: "All", duration: 0 }, // 0 means show all available data
   ];
 
   const currentGranularity =
-    granularityOptions.find((g) => g.id === timeRange.granularity) || granularityOptions[3];
+    granularityOptions.find((g) => g.id === timeRange.granularity) || granularityOptions[0];
 
-  // Fixed date range: September 12, 2025 to now
-  const fixedStartDate = new Date("2025-09-12T00:00:00Z");
-  const fixedEndDate = new Date();
+  // Dynamic date range based on current time
+  const now = new Date();
+  const getTimeRange = () => {
+    const currentGranularity = granularityOptions.find((g) => g.id === timeRange.granularity) || granularityOptions[0];
+    
+    if (currentGranularity.id === "all") {
+      // For "All", show from September 12, 2025 to now
+      return {
+        start: new Date("2025-09-12T00:00:00Z"),
+        end: now,
+      };
+    } else {
+      // For "day" and "week", show from X hours/days ago to now
+      const duration = currentGranularity.duration;
+      return {
+        start: new Date(now.getTime() - duration),
+        end: now,
+      };
+    }
+  };
+  
+  const { start: fixedStartDate, end: fixedEndDate } = getTimeRange();
   const totalDuration = fixedEndDate.getTime() - fixedStartDate.getTime();
 
   // Auto-play functionality
@@ -87,24 +105,27 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
   const handleGranularityChange = (granularity: string) => {
     const option = granularityOptions.find((g) => g.id === granularity);
     if (option) {
-      const currentTime = new Date(
-        fixedStartDate.getTime() + (totalDuration * currentPosition) / 100
-      );
-      const center = currentTime;
-      const newStart = new Date(center.getTime() - option.duration / 2);
-      const newEnd = new Date(center.getTime() + option.duration / 2);
-
-      onChange({
-        start:
-          Math.max(newStart.getTime(), fixedStartDate.getTime()) > fixedStartDate.getTime()
-            ? newStart
-            : fixedStartDate,
-        end:
-          Math.min(newEnd.getTime(), fixedEndDate.getTime()) < fixedEndDate.getTime()
-            ? newEnd
-            : fixedEndDate,
-        granularity: granularity as any,
-      });
+      const now = new Date();
+      
+      if (option.id === "all") {
+        // For "All", show from September 12, 2025 to now
+        onChange({
+          start: new Date("2025-09-12T00:00:00Z"),
+          end: now,
+          granularity: granularity as any,
+        });
+      } else {
+        // For "day" and "week", show from X hours/days ago to now
+        const duration = option.duration;
+        onChange({
+          start: new Date(now.getTime() - duration),
+          end: now,
+          granularity: granularity as any,
+        });
+      }
+      
+      // Reset position to end (now) when changing granularity
+      setCurrentPosition(100);
     }
   };
 
@@ -119,29 +140,23 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
     const currentTime = getCurrentDateTime();
 
     switch (timeRange.granularity) {
-      case "months":
-        return currentTime.toLocaleDateString("en-US", { month: "long", year: "numeric" });
-      case "weeks":
-        return `Week of ${currentTime.toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-          year: "numeric",
-        })}`;
-      case "days":
+      case "day":
         return currentTime.toLocaleDateString("en-US", {
           weekday: "long",
           month: "long",
           day: "numeric",
           year: "numeric",
         });
-      case "hours":
-        return currentTime.toLocaleString("en-US", {
-          weekday: "long",
-          month: "long",
+      case "week":
+        return `Week of ${currentTime.toLocaleDateString("en-US", {
+          month: "short",
           day: "numeric",
           year: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
+        })}`;
+      case "all":
+        return currentTime.toLocaleDateString("en-US", { 
+          month: "long", 
+          year: "numeric" 
         });
       default:
         return currentTime.toLocaleDateString();
@@ -186,7 +201,17 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
           <div>
             <div className="font-medium text-white">{formatDateRange()}</div>
             <div className="text-sm text-cyan-200">
-              Viewing {currentGranularity.label.toLowerCase()} resolution • August 10, 2025 to now (Local Time)
+              Viewing {currentGranularity.label.toLowerCase()} resolution • {(() => {
+                const now = new Date();
+                if (currentGranularity.id === "all") {
+                  return "September 12, 2025 to now (Local Time)";
+                } else if (currentGranularity.id === "day") {
+                  return "Last 24 hours to now (Local Time)";
+                } else if (currentGranularity.id === "week") {
+                  return "Last 7 days to now (Local Time)";
+                }
+                return "Local Time";
+              })()}
             </div>
           </div>
         </div>
@@ -203,6 +228,28 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
 
       {/* Timeline Slider */}
       <div className="space-y-8">
+        {/* Time Range Indicator */}
+        <div className="flex items-center justify-between text-sm text-cyan-200">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-cyan-400 rounded-full"></div>
+            <span>Start: {fixedStartDate.toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-cyan-600 rounded-full"></div>
+            <span>End: {fixedEndDate.toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}</span>
+          </div>
+        </div>
+        
         <div className="relative">
           <input
             type="range"
@@ -219,7 +266,6 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
           {/* Timeline markers */}
           <div className="absolute -bottom-6 left-0 right-0 flex justify-between text-xs text-cyan-200">
             {Array.from({ length: 7 }, (_, i) => {
-              const totalDuration = fixedEndDate.getTime() - fixedStartDate.getTime();
               const markerTime = new Date(fixedStartDate.getTime() + (totalDuration * i) / 6);
               const localTime = markerTime.toLocaleDateString("en-US", {
                 month: "short",
@@ -229,6 +275,21 @@ export function TimelineSlider({ timeRange, onChange, variant = "glass" }: Timel
               });
               return <span key={i}>{localTime}</span>;
             })}
+          </div>
+          
+          {/* Current Selection Indicator */}
+          <div className="absolute -top-8 left-0 right-0 flex justify-center">
+            <div className="bg-cyan-600/90 backdrop-blur text-white px-3 py-1 rounded-full text-xs font-medium">
+              {(() => {
+                const currentTime = new Date(fixedStartDate.getTime() + (totalDuration * currentPosition) / 100);
+                return currentTime.toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                });
+              })()}
+            </div>
           </div>
         </div>
 

--- a/client/types/research.ts
+++ b/client/types/research.ts
@@ -9,7 +9,7 @@ export interface Parameter {
 export interface TimeRange {
   start: Date;
   end: Date;
-  granularity: 'months' | 'weeks' | 'days' | 'hours';
+  granularity: 'day' | 'week' | 'all';
 }
 
 export interface MapInstance {


### PR DESCRIPTION
Changes:
Simplified timeline to Day/Week/All options
Added time range indicators (start/end times)
Added current selection time display
Fixed Day mode to show 24-hour format (00:00, 01:00, etc.)
Fixed SWOT timestamp to show actual data time instead of user selection

Files Modified:
client/components/TimelineSlider.tsx
client/components/CanvasInteractiveMap.tsx
client/app/page.tsx
client/types/research.ts